### PR TITLE
Multiple fixes

### DIFF
--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -13,13 +13,17 @@ void arm9main(void)
     memcpy(&g_takeoverParameters, (const void *)0x22200000, sizeof(g_takeoverParameters));
     size_t fileOffset = g_takeoverParameters.payloadFileOffset;
 
-    switch (g_takeoverParameters.firmTid & 0xFFFF) {
-        case 0x0003:
-        case 0x0002:
-            PXISendWord(0x0000CAFE);
-            break;
-        default:
-            break;
+    if(g_takeoverParameters.firmTid != 0xFFFFFFFF) {
+      switch (g_takeoverParameters.firmTid & 0xFFFF) {
+          case 0x0003:
+          case 0x0002:
+              PXISendWord(0x0000CAFE);
+              break;
+          default:
+              break;
+      }
+    } else {
+      PXISendWord(0x0000CAFE);
     }
 
     while (!PXIIsSendFIFOEmpty());

--- a/source/start.s
+++ b/source/start.s
@@ -6,7 +6,7 @@ FUNCTION _start, .crt0
     .word   arm9_bin
 
 start:
-    push    {r4, lr}
+    push    {r0-r4, lr}
 
     // Zero-fill bss
     ldr     r0, =__bss_start__
@@ -15,6 +15,7 @@ start:
     sub     r2, r2, r0
     bl      memset
 
+    pop     {r0-r3}
     bl      takeoverMain
     cmp     r0, #0
     popne   {r4, pc}


### PR DESCRIPTION
- registers holding parameters for `takeoverMain` were not saved before clearing .bss 
- `p9TakeoverMain` did not fake the response to PXIMC:Shutdown
- `p9TakeoverMain` did not properly setup the l1 table entries
- `arm9main` did not handle tid 0xFFFFFFFF and did not send `0xCAFE`